### PR TITLE
Some fixes

### DIFF
--- a/compat/cdbr.c
+++ b/compat/cdbr.c
@@ -36,8 +36,14 @@
 #endif
 
 #include <sys/mman.h>
+
+/* Not all systems have MAP_FILE|MAP_SHARED defined in sys/mman.h */
+#ifndef MAP_FILE
+#define MAP_FILE 0
+#endif
+
 #include <sys/stat.h>
-#include <cdbr.h>
+#include "cdbr.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -45,7 +51,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <mi_vector_hash.h>
+#include "mi_vector_hash.h"
 #define SET_ERRNO(val) errno = (val)
 
 struct cdbr {


### PR DESCRIPTION
Not all systems have `MAP_FILE|MAP_SHARED` defined in `sys/mman.h`, this causes the following error on these systems:

```C
c99 -O -Wall -Wpedantic -D TERMINFO_COMPILE -D TERMINFO_COMPAT -D TERMINFO_DB -D _XOPEN_SOURCE=700 -I compat -I lib/libcurses -I lib/libterminfo -I lib/libform -I lib/libmenu -I lib/libpanel   -c -o usr.bin/infocmp/infocmp.o usr.bin/infocmp/infocmp.c
compat/cdbr.c: In function ‘cdbr_open’:
compat/cdbr.c:102:37: error: ‘MAP_FILE’ undeclared (first use in this function); did you mean ‘MAP_FAILED’?
  102 |  base = mmap(NULL, size, PROT_READ, MAP_FILE|MAP_SHARED, fd, 0);
      |                                     ^~~~~~~~
      |                                     MAP_FAILED
compat/cdbr.c:102:37: note: each undeclared identifier is reported only once for each function it appears in
c99 -O -Wall -Wpedantic -D TERMINFO_COMPILE -D TERMINFO_COMPAT -D TERMINFO_DB -D _XOPEN_SOURCE=700 -I compat -I lib/libcurses -I lib/libterminfo -I lib/libform -I lib/libmenu -I lib/libpanel   -c -o usr.bin/tabs/tabs.o usr.bin/tabs/tabs.c
make: *** [<builtin>: compat/cdbr.o] Error 1
make: *** Waiting for unfinished jobs....
```

The macros `MAP_FILE` and `MAP_SHARED` are neither in `sys/mman.h` nor in `bits/mman.h`, instead they're in `bits/mman-linux.h` in which is explicitly stated to not be included directly.